### PR TITLE
Increase ZodLazy processing depth

### DIFF
--- a/src/converter/convert-schemas.ts
+++ b/src/converter/convert-schemas.ts
@@ -86,7 +86,7 @@ function resolveDeferred(schema: LazyDeferredModel): Model {
 
 function processDeferredSchemas(
   obj: (NamedModel | LazyDeferredModel) | (NamedModel | LazyDeferredModel)[],
-  deep = 2
+  deep = 10
 ): NamedModel[] {
   // Check if the input is an object and not null
   if (typeof obj === 'object' && obj !== null) {
@@ -149,7 +149,7 @@ export function convertSchemas(
     })
   );
 
-  // to handle if there are any deferred schemas generated because of LazyZod
+  // to handle if there are any deferred schemas generated because of ZodLazy
   return processDeferredSchemas(schemas);
 }
 


### PR DESCRIPTION
There was one schema that uses ZodLazy in depth level 3. The pervious value was only 2 which is very conservative.
Now it is updated to 10 to accommodate with any possible future structure. The processing speed is still fast and this change has un-noticeable effect.