### PR TITLE
fix: not rendering `default` for referenced objects

### DIFF
--- a/src/converter/convert-schemas.ts
+++ b/src/converter/convert-schemas.ts
@@ -167,6 +167,7 @@ function createModelOrRef(
       kind: 'ref',
       ref: {
         ...ref,
+        ...convertSchema(schema, exportedSchemas),
         ...schemaToMeta(schema, implicitOptional),
       },
     };


### PR DESCRIPTION
Fix for https://github.com/nucypher/taco-web/commit/992af765f2bd9d2d92c6e5365a74777b65c15d28